### PR TITLE
v0.2.0a - Nightly 1279

### DIFF
--- a/ClientModule/editorwindow.cpp
+++ b/ClientModule/editorwindow.cpp
@@ -734,29 +734,17 @@ void EditorWindow::keyPressEvent(QKeyEvent *e){
 //CHECK HOW THIS WINDOW IS CLOSED   -   IS AN OVERRIDE OF A ORIGINAL CLOSE EVENT
 void EditorWindow::closeEvent(QCloseEvent * event){
 
+    //If is a forced close then, ask the user if he really wants to close the document
     if(BruteClose==true){
-        //If is a forced close then disconnect the user
         QMessageBox::StandardButton reply;
         reply = QMessageBox::question(this, "Uscita", "Uscire dal documento?",
                                       QMessageBox::Yes|QMessageBox::No);
         if (reply == QMessageBox::Yes) {
-
-        //Get data from the form
-        QString user = _client->getUsername();
-        QByteArray ba_user = user.toLocal8Bit();
-        const char *c_user = ba_user.data();
-
-        //Serialize data
-        json j;
-        jsonUtility::to_jsonUser(j, "LOGOUT_REQUEST", c_user);
-        const std::string req = j.dump();
-
-        sendRequestMsg(req);    //Send data (header and body)
-        qDebug()<<"FORCED CLOSE -> USER " << _client->getUsername() <<"DISCONNECTED";
-        }else{
-            event->ignore();    //IGNORE FORCED EXIT EVENT
+            event->ignore();    //IGNORE FORCED CLOSE EVENT --> Is the "override", i'll handle the close event with a LogoutRequest();
+            LogoutRequest();    //By ignoring the closing event, the LogoutRequest() brings me back to the menuWindow.
+         }else{
+            event->ignore();    //IGNORE FORCED CLOSE EVENT --> Stay in this window (EditorWindow)
         }
-
     }
 }
 

--- a/ClientModule/editorwindow.h
+++ b/ClientModule/editorwindow.h
@@ -19,7 +19,6 @@ public:
     ~EditorWindow();
     bool eventFilter(QObject *obj, QEvent *ev);
 private slots:
-    //void on_pushButton_3_clicked(); --> Old Rename Function Deprecated
 
     //Button for change style of the text
     void on_buttonGrassetto_clicked();

--- a/ClientModule/versioninfo.h
+++ b/ClientModule/versioninfo.h
@@ -13,7 +13,7 @@ private:
     QString str;
 public:
     //CONSTRUCTOR WITHOUT PARAMETER (Default)
-    VersionInfo(): Major(0), Minor(2), Patch(0), ReleaseType("a"), BuildTypeAndNumber("Daily 1278"){
+    VersionInfo(): Major(0), Minor(2), Patch(0), ReleaseType("a"), BuildTypeAndNumber("Nightly 1279"){
         str = "v"+QString::number(Major)+"."+QString::number(Minor)+"."+QString::number(Patch)+ReleaseType+" - "+BuildTypeAndNumber;
     }
 


### PR DESCRIPTION
Better handling of Close Event on EditorWindow.
Now a brute forced close (like ALT+F4 or X button in titlebar) will no longer close the entire application, but ask the user if want to close the Edito (in this case the user will be redirected to MenuWindow) or not.